### PR TITLE
Avoid Error in owncloud log due to undefined index when calling OCP\Config::getAppValue

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -12,7 +12,7 @@
 
 OCP\App::registerAdmin ( 'piwik', 'settings-admin' );
 
-$internal = OCP\Config::getAppValue ( 'piwik', 'internal' );
+$internal = OCP\Config::getAppValue ( 'piwik', 'internal','no' );
 
 if ($internal === 'yes') {
    OCP\Util::addScript ( 'piwik', 'piwik');

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -12,7 +12,7 @@
 
 OCP\App::registerAdmin ( 'piwik', 'settings-admin' );
 
-$internal = OCP\Config::getAppValue ( 'piwik', 'internal','no' );
+$internal = OCP\Config::getAppValue ( 'piwik', 'internal','' );
 
 if ($internal === 'yes') {
    OCP\Util::addScript ( 'piwik', 'piwik');


### PR DESCRIPTION
Not sure about this, but I think the missing third argument is causing an error in my owncloud log.